### PR TITLE
Add github action tag versioning workflow

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,14 @@
+---
+name: Tag Versioning
+
+on:
+  release:
+    types: 
+      - published
+      - edited
+
+jobs:
+  actions-tagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@v2.0.2


### PR DESCRIPTION
Based on the [GitHub Actions versioning](https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning) recommendations, this workflow will create/update major version tag (e.g. `v3`) to point to the latest version when a release is published. 

